### PR TITLE
Update CMakeLists to link zlib.

### DIFF
--- a/tests/mc/phantom/CMakeLists.txt
+++ b/tests/mc/phantom/CMakeLists.txt
@@ -31,6 +31,8 @@ endif ()
 find_package(GDCM REQUIRED)
 include(${GDCM_USE_FILE})
 
+find_package(ZLIB)
+
 if (APPLE)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation)
 endif ()
@@ -55,4 +57,5 @@ target_link_libraries(phantom_env
         gdcmIOD
         gdcmMSFF
         gdcmjpeg16
+        ZLIB::ZLIB
         )

--- a/tests/mc/tps/CMakeLists.txt
+++ b/tests/mc/tps/CMakeLists.txt
@@ -28,6 +28,8 @@ endif ()
 find_package(GDCM REQUIRED)
 include(${GDCM_USE_FILE})
 
+find_package(ZLIB)
+
 if (APPLE)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation)
 endif ()
@@ -52,4 +54,5 @@ target_link_libraries(tps_env
         gdcmIOD
         gdcmMSFF
         gdcmjpeg16
+        ZLIB::ZLIB
         )


### PR DESCRIPTION
I failed to  build the phantom test because of missing ZLIB in CMakeLists.txt
```
$ cd moquimc/tests/mc/phantom
$ cmake .
$ make
```
The compiler cannot find crc32.
```
#14 12.26 CMakeFiles/phantom_env.dir/phantom_env.cpp.o: In function `mqi::io::save_npz(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
#14 12.26 tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text+0x1387): undefined reference to `crc32'
#14 12.26 tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text+0x13c6): undefined reference to `crc32'
#14 12.26 CMakeFiles/phantom_env.dir/phantom_env.cpp.o: In function `void mqi::io::save_npz<unsigned int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
#14 12.26 tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text._ZN3mqi2io8save_npzIjEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_[_ZN3mqi2io8save_npzIjEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_]+0x8ba): undefined reference to `crc32'
#14 12.26 tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text._ZN3mqi2io8save_npzIjEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_[_ZN3mqi2io8save_npzIjEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_]+0x8e6): undefined reference to `crc32'
#14 12.26 CMakeFiles/phantom_env.dir/phantom_env.cpp.o: In function `void mqi::io::save_npz<double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
#14 12.26 tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text._ZN3mqi2io8save_npzIdEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_[_ZN3mqi2io8save_npzIdEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_]+0x8ba): undefined reference to `crc32'
#14 12.26 CMakeFiles/phantom_env.dir/phantom_env.cpp.o:tmpxft_000000b9_00000000-6_phantom_env.cudafe1.cpp:(.text._ZN3mqi2io8save_npzIdEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_[_ZN3mqi2io8save_npzIdEEvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_PT_mS7_]+0x8e6): more undefined references to `crc32' follow
```